### PR TITLE
Fix error in init and unpin call.

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -35,22 +35,21 @@ impl Env {
 
 impl WasmerEnv for Env {
     fn init_with_instance(&mut self, instance: &Instance) -> Result<(), HostEnvInitError> {
-        let mem = instance
+        let mem: Memory = instance
             .exports
-            .get_memory("memory")
-            .map_err(HostEnvInitError::from)?
-            .clone();
-        if let Ok(func) = instance.exports.get_function("__new") {
-            self.fn_new = Some(func.clone())
+            .get_with_generics_weak("memory")
+            .map_err(HostEnvInitError::from)?;
+        if let Ok(func) = instance.exports.get_with_generics_weak("__new") {
+            self.fn_new = Some(func)
         }
-        if let Ok(func) = instance.exports.get_function("__pin") {
-            self.fn_pin = Some(func.clone())
+        if let Ok(func) = instance.exports.get_with_generics_weak("__pin") {
+            self.fn_pin = Some(func)
         }
-        if let Ok(func) = instance.exports.get_function("__unpin") {
-            self.fn_unpin = Some(func.clone())
+        if let Ok(func) = instance.exports.get_with_generics_weak("__unpin") {
+            self.fn_unpin = Some(func)
         }
-        if let Ok(func) = instance.exports.get_function("__collect") {
-            self.fn_collect = Some(func.clone())
+        if let Ok(func) = instance.exports.get_with_generics_weak("__collect") {
+            self.fn_collect = Some(func)
         }
         self.memory.initialize(mem);
         Ok(())

--- a/src/string_ptr.rs
+++ b/src/string_ptr.rs
@@ -80,7 +80,7 @@ impl Write<String> for StringPtr {
             Ok(Box::new(*self))
         } else {
             // unpin old ptr
-            let unpin = export_asr!(fn_pin, env);
+            let unpin = export_asr!(fn_unpin, env);
             unpin.call(&[Value::I32(self.offset().try_into()?)])?;
 
             // collect
@@ -94,7 +94,7 @@ impl Write<String> for StringPtr {
 
     fn free(self, env: &Env) -> anyhow::Result<()> {
         // unpin
-        let unpin = export_asr!(fn_pin, env);
+        let unpin = export_asr!(fn_unpin, env);
         unpin.call(&[Value::I32(self.offset().try_into()?)])?;
 
         // collect


### PR DESCRIPTION
The first fix is to use weak reference in `init_with_instance` as asked by  Wasmer here : https://github.com/wasmerio/wasmer/blob/master/lib/api/src/sys/env.rs#L82

The second fix is to use the unpin function where asked in comments but was the pin called instead.